### PR TITLE
fix: 🐛 Select Component

### DIFF
--- a/src/ui/select/select.component.tsx
+++ b/src/ui/select/select.component.tsx
@@ -79,7 +79,7 @@ const Select = React.forwardRef<Ref, SelectProps>((props, ref) => {
           {title}
         </Text>
       ) : (
-        { title }
+        title
       );
     }
 
@@ -87,6 +87,9 @@ const Select = React.forwardRef<Ref, SelectProps>((props, ref) => {
   };
 
   const renderFooter = () => {
+    if (!multiple) {
+      return;
+    }
     if (footer) {
       return footer;
     }


### PR DESCRIPTION

-Before With Multiple set as false  still showing footer

![image](https://user-images.githubusercontent.com/10059733/91640698-6ce02e00-ea17-11ea-8abc-d86b79b17761.png)
![image](https://user-images.githubusercontent.com/10059733/91640703-723d7880-ea17-11ea-9cff-0aabfc05793c.png)

Now
![image](https://user-images.githubusercontent.com/10059733/91640709-79fd1d00-ea17-11ea-81e8-fe11430877a7.png)

- Before With ReactNode as title type
![image](https://user-images.githubusercontent.com/10059733/91640721-91d4a100-ea17-11ea-9862-2a8e5f7d166e.png)

Now
![image](https://user-images.githubusercontent.com/10059733/91640734-a9138e80-ea17-11ea-8fa7-02e8f923f2db.png)

