### PR TITLE
refac: moved children as not require props, in Select.Container

### DIFF
--- a/src/ui/select/select.type.tsx
+++ b/src/ui/select/select.type.tsx
@@ -44,7 +44,7 @@ export interface SelectProps
   left?: number;
   multiple?: boolean;
   value: any;
-  children: React.ReactElement[] | React.ReactElement;
+  children?: React.ReactElement[] | React.ReactElement;
   footer?: React.ReactElement[] | React.ReactElement;
   onSelect: (value: any) => void;
   data: any[];


### PR DESCRIPTION
I am using the `Select.Container` doc example and because I am using TS, I always receive an error message saying the children props is required! But it is not :) 