### PR TITLE
fix: type declaration path

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A Utility-First React Native UI Framework",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
-  "types": "lib/typescript/index.d.ts",
+  "types": "lib/typescript/src/index.d.ts",
   "react-native": "src/index.tsx",
   "source": "src/index.tsx",
   "files": [


### PR DESCRIPTION
The type declaration path moved in the last update 1.0.54, from:    
`lib/typescript/index.d.ts`.  
to   
`lib/typescript/src/index.d.ts`.  