### PR TITLE
Added Carousel component

### DIFF
--- a/example/src/components/Carousel.tsx
+++ b/example/src/components/Carousel.tsx
@@ -1,11 +1,11 @@
-import React from "react";
-import { ScrollView } from "react-native";
-import { Carousel, Div, Text } from "react-native-magnus";
-import { DivProps } from "src/ui/div/div.type";
+import React from 'react';
+import { ScrollView } from 'react-native';
+import { Carousel, Div, Text } from 'react-native-magnus';
+import { DivProps } from 'src/ui/div/div.type';
 
-import ExampleHeader from "../utils/ExampleHeader";
-import ExamplePage from "../utils/ExamplePage";
-import ExampleSection from "../utils/ExampleSection";
+import ExampleHeader from '../utils/ExampleHeader';
+import ExamplePage from '../utils/ExamplePage';
+import ExampleSection from '../utils/ExampleSection';
 
 const CarouselComponent: React.FC = () => {
   return (
@@ -57,7 +57,7 @@ const CarouselComponent: React.FC = () => {
           </Card>
         </ExampleSection>
 
-        <ExampleSection name="2 items by interval">
+        <ExampleSection name="2 items by page">
           <Carousel itemsPerPage={2}>
             <Carousel.Item>
               <Div p="xl">
@@ -94,7 +94,7 @@ const CarouselComponent: React.FC = () => {
           </Carousel>
         </ExampleSection>
 
-        <ExampleSection name="2 items by interval but has only 3 items">
+        <ExampleSection name="2 items by page but has odd items number">
           <Carousel itemsPerPage={2}>
             <Carousel.Item>
               <Div p="xl">
@@ -116,6 +116,49 @@ const CarouselComponent: React.FC = () => {
               <Div p="xl">
                 <Text textTransform="uppercase" fontWeight="bold">
                   Title 3
+                </Text>
+                <Text>This is a content card</Text>
+              </Div>
+            </Carousel.Item>
+          </Carousel>
+
+          <Carousel itemsPerPage={2}>
+            <Carousel.Item>
+              <Div p="xl">
+                <Text textTransform="uppercase" fontWeight="bold">
+                  Title 1
+                </Text>
+                <Text>This is a content card</Text>
+              </Div>
+            </Carousel.Item>
+            <Carousel.Item>
+              <Div p="xl">
+                <Text textTransform="uppercase" fontWeight="bold">
+                  Title 2
+                </Text>
+                <Text>This is a content card</Text>
+              </Div>
+            </Carousel.Item>
+            <Carousel.Item>
+              <Div p="xl">
+                <Text textTransform="uppercase" fontWeight="bold">
+                  Title 3
+                </Text>
+                <Text>This is a content card</Text>
+              </Div>
+            </Carousel.Item>
+            <Carousel.Item>
+              <Div p="xl">
+                <Text textTransform="uppercase" fontWeight="bold">
+                  Title 4
+                </Text>
+                <Text>This is a content card</Text>
+              </Div>
+            </Carousel.Item>
+            <Carousel.Item>
+              <Div p="xl">
+                <Text textTransform="uppercase" fontWeight="bold">
+                  Title 5
                 </Text>
                 <Text>This is a content card</Text>
               </Div>
@@ -190,7 +233,7 @@ const CarouselComponent: React.FC = () => {
                           w={20}
                           h={7}
                           rounded="circle"
-                          bg={selectedPage === index ? "white" : "gray700"}
+                          bg={selectedPage === index ? 'white' : 'gray700'}
                           mx="xs"
                           key={index}
                         />

--- a/example/src/components/Carousel.tsx
+++ b/example/src/components/Carousel.tsx
@@ -1,0 +1,224 @@
+import React from "react";
+import { ScrollView } from "react-native";
+import { Carousel, Div, Text } from "react-native-magnus";
+import { DivProps } from "src/ui/div/div.type";
+
+import ExampleHeader from "../utils/ExampleHeader";
+import ExamplePage from "../utils/ExamplePage";
+import ExampleSection from "../utils/ExampleSection";
+
+const CarouselComponent: React.FC = () => {
+  return (
+    <ExamplePage>
+      <ExampleHeader name="carousel" />
+
+      <ScrollView>
+        <ExampleSection name="default">
+          <Card>
+            <Carousel>
+              <Carousel.Item>
+                <Div p="xl">
+                  <Text textTransform="uppercase" fontWeight="bold">
+                    Title
+                  </Text>
+                  <Text>This is a content card</Text>
+                </Div>
+              </Carousel.Item>
+              <Carousel.Item>
+                <Div p="xl">
+                  <Text>2</Text>
+                </Div>
+              </Carousel.Item>
+
+              <Text>2</Text>
+            </Carousel>
+          </Card>
+        </ExampleSection>
+
+        <ExampleSection name="no indicators">
+          <Card>
+            <Carousel showIndicators={false}>
+              <Carousel.Item>
+                <Div p="xl">
+                  <Text textTransform="uppercase" fontWeight="bold">
+                    Title
+                  </Text>
+                  <Text>This is a content card</Text>
+                </Div>
+              </Carousel.Item>
+              <Carousel.Item>
+                <Div p="xl">
+                  <Text>2</Text>
+                </Div>
+              </Carousel.Item>
+
+              <Text>2</Text>
+            </Carousel>
+          </Card>
+        </ExampleSection>
+
+        <ExampleSection name="2 items by interval">
+          <Carousel itemsPerPage={2}>
+            <Carousel.Item>
+              <Div p="xl">
+                <Text textTransform="uppercase" fontWeight="bold">
+                  Title 1
+                </Text>
+                <Text>This is a content card</Text>
+              </Div>
+            </Carousel.Item>
+            <Carousel.Item>
+              <Div p="xl">
+                <Text textTransform="uppercase" fontWeight="bold">
+                  Title 2
+                </Text>
+                <Text>This is a content card</Text>
+              </Div>
+            </Carousel.Item>
+            <Carousel.Item>
+              <Div p="xl">
+                <Text textTransform="uppercase" fontWeight="bold">
+                  Title 3
+                </Text>
+                <Text>This is a content card</Text>
+              </Div>
+            </Carousel.Item>
+            <Carousel.Item>
+              <Div p="xl">
+                <Text textTransform="uppercase" fontWeight="bold">
+                  Title 4
+                </Text>
+                <Text>This is a content card</Text>
+              </Div>
+            </Carousel.Item>
+          </Carousel>
+        </ExampleSection>
+
+        <ExampleSection name="2 items by interval but has only 3 items">
+          <Carousel itemsPerPage={2}>
+            <Carousel.Item>
+              <Div p="xl">
+                <Text textTransform="uppercase" fontWeight="bold">
+                  Title 1
+                </Text>
+                <Text>This is a content card</Text>
+              </Div>
+            </Carousel.Item>
+            <Carousel.Item>
+              <Div p="xl">
+                <Text textTransform="uppercase" fontWeight="bold">
+                  Title 2
+                </Text>
+                <Text>This is a content card</Text>
+              </Div>
+            </Carousel.Item>
+            <Carousel.Item>
+              <Div p="xl">
+                <Text textTransform="uppercase" fontWeight="bold">
+                  Title 3
+                </Text>
+                <Text>This is a content card</Text>
+              </Div>
+            </Carousel.Item>
+          </Carousel>
+        </ExampleSection>
+
+        <ExampleSection name="custom indicators">
+          <Carousel
+            itemsPerPage={2}
+            renderIndicators={({ totalPages, selectedPage }) => (
+              <Div flex={1} alignItems="center">
+                <Text fontSize="xl">
+                  Pages: {selectedPage}/{totalPages}
+                </Text>
+              </Div>
+            )}
+          >
+            <Carousel.Item>
+              <Div p="xl">
+                <Text>1</Text>
+              </Div>
+            </Carousel.Item>
+            <Carousel.Item>
+              <Div p="xl">
+                <Text>2</Text>
+              </Div>
+            </Carousel.Item>
+          </Carousel>
+
+          <Card mt="xl">
+            <Carousel
+              renderIndicators={({ totalPages, selectedPage }) => (
+                <Div flex={1} position="absolute" right={10} top={6}>
+                  <Text>
+                    {selectedPage}/{totalPages}
+                  </Text>
+                </Div>
+              )}
+            >
+              <Carousel.Item>
+                <Div p="xl">
+                  <Text>1</Text>
+                </Div>
+              </Carousel.Item>
+              <Carousel.Item>
+                <Div p="xl">
+                  <Text>2</Text>
+                </Div>
+              </Carousel.Item>
+            </Carousel>
+          </Card>
+
+          <Card mt="xl" bg="black" rounded="sm">
+            <Carousel
+              renderIndicators={({ totalPages, selectedPage }) => (
+                <Div
+                  w="100%"
+                  position="absolute"
+                  alignItems="center"
+                  justifyContent="center"
+                  bottom={10}
+                  row
+                >
+                  {Array(totalPages)
+                    .fill(0)
+                    .map((_, index) => {
+                      index++;
+
+                      return (
+                        <Div
+                          w={20}
+                          h={7}
+                          rounded="circle"
+                          bg={selectedPage === index ? "white" : "gray700"}
+                          mx="xs"
+                          key={index}
+                        />
+                      );
+                    })}
+                </Div>
+              )}
+            >
+              <Carousel.Item>
+                <Div p="xl">
+                  <Text color="white">1</Text>
+                </Div>
+              </Carousel.Item>
+              <Carousel.Item>
+                <Div p="xl">
+                  <Text color="white">2</Text>
+                </Div>
+              </Carousel.Item>
+            </Carousel>
+          </Card>
+        </ExampleSection>
+      </ScrollView>
+    </ExamplePage>
+  );
+};
+
+const Card: React.FC<DivProps> = (props) => {
+  return <Div bg="white" shadow="sm" {...props} />;
+};
+
+export default CarouselComponent;

--- a/example/src/components/Collapse.tsx
+++ b/example/src/components/Collapse.tsx
@@ -1,10 +1,9 @@
-import React from "react";
-import { ScrollView } from "react-native";
-import { Collapse, Icon, Text } from "react-native-magnus";
-import ExamplePage from "../utils/ExamplePage";
-import ExampleHeader from "../utils/ExampleHeader";
-import ExampleSection from "../utils/ExampleSection";
-import { CollapseGroup } from "src/ui/collapse/group.component";
+import React from 'react';
+import { ScrollView } from 'react-native';
+import { Collapse, Icon, Text } from 'react-native-magnus';
+import ExamplePage from '../utils/ExamplePage';
+import ExampleHeader from '../utils/ExampleHeader';
+import ExampleSection from '../utils/ExampleSection';
 
 const CollapseComponent: React.FC = () => {
   return (

--- a/example/src/items.ts
+++ b/example/src/items.ts
@@ -2,6 +2,7 @@ import { ComponentType } from "react";
 import AvatarComponent from "./components/Avatar";
 import BadgeComponent from "./components/Badge";
 import ButtonComponent from "./components/Button";
+import CarouselComponent from "./components/Carousel";
 import CheckboxComponent from "./components/Checkbox";
 import CollapseComponent from "./components/Collapse";
 import DivComponent from "./components/Div";
@@ -22,6 +23,7 @@ import TextComponent from "./components/Text";
 import ToggleComponent from "./components/Toggle";
 import TooltipComponent from "./components/Tooltip";
 import HomeExample1 from "./pages/HomeExample1";
+import IntroExample1 from "./pages/IntroExample1";
 import LoginExample1 from "./pages/LoginExample1";
 import LoginExample2 from "./pages/LoginExample2";
 
@@ -46,6 +48,11 @@ export const pages: ExampleComponentType[] = [
     onScreenName: "Home Example #1",
     navigationPath: "HomeExample1",
     component: HomeExample1,
+  },
+  {
+    onScreenName: "Intro Example #1",
+    navigationPath: "IntroExample1",
+    component: IntroExample1,
   },
 ];
 
@@ -151,5 +158,10 @@ export const components: ExampleComponentType[] = [
     navigationPath: "Select",
     onScreenName: "Select",
     component: SelectComponent,
+  },
+  {
+    navigationPath: "Carousel",
+    onScreenName: "Carousel",
+    component: CarouselComponent,
   },
 ];

--- a/example/src/pages/IntroExample1.tsx
+++ b/example/src/pages/IntroExample1.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { Carousel, Div, Fab, Text } from "react-native-magnus";
+import ExamplePage from "../utils/ExamplePage";
+
+const IntroExample1: React.FC = () => {
+  return (
+    <ExamplePage>
+      <Carousel
+        flex={1}
+        renderIndicators={({ totalPages, selectedPage }) => (
+          <Div
+            w="100%"
+            position="absolute"
+            alignItems="center"
+            justifyContent="center"
+            bottom={20}
+            row
+          >
+            {Array(totalPages)
+              .fill(0)
+              .map((_, index) => {
+                return (
+                  <Div
+                    w={32}
+                    h={6}
+                    rounded="circle"
+                    bg={selectedPage === index + 1 ? "black" : "white"}
+                    mx="xs"
+                    key={index}
+                  />
+                );
+              })}
+          </Div>
+        )}
+      >
+        <Carousel.Item>
+          <Div flex={1} bg="pink200" px="2xl">
+            <Div flex={1} justifyContent="center">
+              <Text fontSize="5xl">Welcome to our app</Text>
+              <Text fontSize="xl">Welcome to our app</Text>
+            </Div>
+          </Div>
+        </Carousel.Item>
+        <Carousel.Item>
+          <Div flex={1} bg="green200">
+            <Text>2</Text>
+          </Div>
+        </Carousel.Item>
+
+        <Carousel.Item>
+          <Div flex={1} bg="blue200">
+            <Text>3</Text>
+          </Div>
+        </Carousel.Item>
+      </Carousel>
+
+      <Fab
+        // onPress={() => }
+        icon="right"
+        fontSize="2xl"
+        h={50}
+        w={50}
+        shadow="xl"
+        shadowColor="red500"
+      />
+    </ExamplePage>
+  );
+};
+
+export default IntroExample1;

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@types/react-native-vector-icons": "^6.4.1",
     "color": "^3.1.2",
     "commitlint": "^8.3.5",
+    "editorconfig": "^0.15.3",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.3",

--- a/src/ui/carousel/carousel.component.tsx
+++ b/src/ui/carousel/carousel.component.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { Div } from '../div/div.component';
+import { ScrollDiv } from '../scrolldiv/scrolldiv.component';
+
+import { CarouselProps, CompoundedCarousel } from './carousel.type';
+import CarouselItem from './item.carousel';
+
+const Carousel: CompoundedCarousel<CarouselProps> = ({
+  children,
+  itemsPerPage = 1,
+  renderIndicators,
+  showIndicators = true,
+  ...props
+}) => {
+  const [selectedPage, setSelectedPage] = React.useState(1);
+  const [totalPages, setTotalPages] = React.useState(1);
+  const [width, setWidth] = React.useState(0);
+
+  const items: JSX.Element[] = React.useMemo(() => {
+    return (
+      React.Children.map(children, (child) => {
+        if (!React.isValidElement(child)) return;
+
+        if (child.type === CarouselItem) return child;
+
+        console.warn('Only children of type Carousel.Item are allowed here.');
+        return null;
+      }) ?? []
+    );
+  }, [children]);
+
+  const init = (width: number) => {
+    // initialise width
+    setWidth(width);
+    // initialise total pages
+    const totalItems = items.length;
+    setTotalPages(Math.ceil(totalItems / itemsPerPage));
+  };
+
+  const getPage = (offset: number) => {
+    for (let i = 1; i <= totalPages; i++) {
+      console.log(
+        `offset: ${offset} / width: ${width} / totalPages: ${totalPages} / pageIndex: ${i}`
+      );
+
+      if (offset + 1 < (width / totalPages) * i) return i;
+      if (i === totalPages) return i;
+    }
+
+    return 0;
+  };
+
+  const internal_renderIndicators = () => {
+    if (renderIndicators) return renderIndicators({ selectedPage, totalPages });
+
+    return (
+      <Div flexDir="row" justifyContent="center" my="lg">
+        {Array(totalPages)
+          .fill(0)
+          .map((_, index) => {
+            return (
+              <Div
+                w={10}
+                h={10}
+                rounded="circle"
+                bg={selectedPage === index + 1 ? 'blue600' : 'gray400'}
+                mx="xs"
+                key={index}
+              />
+            );
+          })}
+      </Div>
+    );
+  };
+
+  return (
+    <>
+      <ScrollDiv
+        {...props}
+        horizontal={true}
+        contentContainerStyle={{
+          width: `${(100 / itemsPerPage) * items.length}%`,
+          flex: 1,
+        }}
+        showsHorizontalScrollIndicator={false}
+        onContentSizeChange={(w, h) => init(w)}
+        onScroll={(data) => {
+          setWidth(data.nativeEvent.contentSize.width);
+          setSelectedPage(getPage(data.nativeEvent.contentOffset.x));
+        }}
+        scrollEventThrottle={200}
+        pagingEnabled
+        decelerationRate="fast"
+      >
+        {items?.map((child, index) => (
+          <Div flex={1} key={index}>
+            {child}
+          </Div>
+        ))}
+      </ScrollDiv>
+
+      {showIndicators && internal_renderIndicators()}
+    </>
+  );
+};
+
+Carousel.Item = CarouselItem;
+
+export { Carousel };

--- a/src/ui/carousel/carousel.style.tsx
+++ b/src/ui/carousel/carousel.style.tsx
@@ -1,0 +1,25 @@
+import { StyleSheet } from 'react-native';
+
+import {
+  getThemeProperty,
+  createShadowStyles,
+  createSpacingStyles,
+  createPositionStyle,
+  createBorderRadiusStyles,
+  createBorderColorStyles,
+  createBorderWidthStyles,
+} from '../../theme/theme.service';
+
+/**
+ * computed style
+ *
+ * @param theme
+ * @param props
+ */
+export const getStyle = (theme: any, props: any) => {
+  const computedStyle: any = {};
+
+  computedStyle.button = {};
+
+  return StyleSheet.create(computedStyle);
+};

--- a/src/ui/carousel/carousel.type.tsx
+++ b/src/ui/carousel/carousel.type.tsx
@@ -1,0 +1,28 @@
+import {
+  BorderPropsType,
+  RoundedPropsType,
+  ShadowPropsType,
+  SpacingPropsType,
+} from '../../theme';
+
+import CarouselItem from './item.carousel';
+
+interface CarouselIndicator {
+  selectedPage: number;
+  totalPages: number;
+}
+
+export interface CarouselProps
+  extends BorderPropsType,
+    RoundedPropsType,
+    ShadowPropsType,
+    SpacingPropsType {
+  flex?: number;
+  itemsPerPage?: number;
+  showIndicators?: boolean;
+  renderIndicators?: (props: CarouselIndicator) => JSX.Element;
+}
+
+export interface CompoundedCarousel<T> extends React.FC<T> {
+  Item: typeof CarouselItem;
+}

--- a/src/ui/carousel/item.carousel.tsx
+++ b/src/ui/carousel/item.carousel.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const CarouselItem: React.FC = ({ children }) => {
+  return <>{children}</>;
+};
+
+export default CarouselItem;

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -58,3 +58,5 @@ export { Select } from './select/select.component';
 export { SelectRef, SelectProps } from './select/select.type';
 export { StatusBar } from './statusbar/statusbar.component';
 export { StatusBarProps } from './statusbar/statusbar.type';
+export { Carousel } from './carousel/carousel.component';
+export { CarouselProps } from './carousel/carousel.type';

--- a/src/ui/scrolldiv/scrolldiv.type.ts
+++ b/src/ui/scrolldiv/scrolldiv.type.ts
@@ -22,7 +22,7 @@ export interface ScrollDivProps
   minH?: number | string;
   minW?: number | string;
   bgImg?: RNImageSourcePropType;
-  bgMode?: 'contain' | 'cover' | 'stretch';
+  bgMode?: 'contain' | 'cover' | 'stretch' | 'repeat';
   flex?: number;
   justifyContent?:
     | 'flex-start'

--- a/yarn.lock
+++ b/yarn.lock
@@ -3804,6 +3804,16 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
+editorconfig@^0.15.3:
+  version "0.15.3"
+  resolved "https://registry.yarnpkg.com/editorconfig/-/editorconfig-0.15.3.tgz#bef84c4e75fb8dcb0ce5cee8efd51c15999befc5"
+  integrity sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==
+  dependencies:
+    commander "^2.19.0"
+    lru-cache "^4.1.5"
+    semver "^5.6.0"
+    sigmund "^1.0.1"
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -6471,7 +6481,7 @@ lowercase-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz#2603e78b7b4b0006cbca2fbcc8a3202558ac9479"
   integrity sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==
 
-lru-cache@^4.0.1:
+lru-cache@^4.0.1, lru-cache@^4.1.5:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
   integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
@@ -8689,6 +8699,11 @@ side-channel@^1.0.2:
   dependencies:
     es-abstract "^1.17.0-next.1"
     object-inspect "^1.7.0"
+
+sigmund@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
+  integrity sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.3"


### PR DESCRIPTION
Added Carousel component.
You can render your own indicators if you want.
As children, it only accept Carousel.Item (a component that does not render anything)

The props are:
- flex?: number;
- itemsPerPage?: number;
- showIndicators?: boolean;
- renderIndicators?: (props: { selectedPage: number; totalPages: number; }) => JSX.Element;

**Known bugs:**
When 'itemsPerPage' is set to any number other than 1 and there are not Carousel.Item enough to fill all pages, scroll to the last item will not change 'selectedPage'