### PR TITLE
Select 'search' fixed

### DIFF
--- a/example/src/components/Input.tsx
+++ b/example/src/components/Input.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { ScrollView } from "react-native";
+import React from 'react';
+import { ScrollView } from 'react-native';
 import {
   Div,
   Input,
@@ -8,11 +8,11 @@ import {
   Select,
   Button,
   SelectRef,
-} from "react-native-magnus";
+} from 'react-native-magnus';
 
-import ExamplePage from "../utils/ExamplePage";
-import ExampleHeader from "../utils/ExampleHeader";
-import ExampleSection from "../utils/ExampleSection";
+import ExamplePage from '../utils/ExamplePage';
+import ExampleHeader from '../utils/ExampleHeader';
+import ExampleSection from '../utils/ExampleSection';
 
 interface CountryCodeType {
   country: {
@@ -22,10 +22,10 @@ interface CountryCodeType {
   code: number;
 }
 const countryCodes: CountryCodeType[] = [
-  { country: { name: "Brazil" }, code: 55 },
-  { country: { name: "Spain" }, code: 34 },
-  { country: { name: "Italy" }, code: 39 },
-  { country: { name: "Portugal" }, code: 351 },
+  { country: { name: 'Brazil' }, code: 55 },
+  { country: { name: 'Spain' }, code: 34 },
+  { country: { name: 'Italy' }, code: 39 },
+  { country: { name: 'Portugal' }, code: 351 },
 ];
 
 const InputComponent: React.FC = () => {
@@ -95,7 +95,7 @@ const InputComponent: React.FC = () => {
             value={selectedCountryCode}
             data={countryCodes}
             onSelect={onSelectCountryCodeOption}
-            searchableProps={["country.name", "code"]}
+            searchableProps={['country.name', 'code']}
             renderItem={(item: CountryCodeType, index: number) => (
               <Select.Option
                 key={index}
@@ -115,20 +115,7 @@ const InputComponent: React.FC = () => {
                 </Div>
               </Select.Option>
             )}
-            title={
-              <Text
-                px="xl"
-                pt="md"
-                pb="lg"
-                fontSize="lg"
-                fontWeight="bold"
-                textTransform="uppercase"
-              >
-                Country phone code
-              </Text>
-            }
-            mt="md"
-            pb="2xl"
+            title="Country phone code"
             roundedTop="xl"
           />
 
@@ -143,7 +130,7 @@ const InputComponent: React.FC = () => {
                   <Text fontWeight="bold" textTransform="uppercase">
                     {selectedCountryCode
                       ? `+${selectedCountryCode.code}`
-                      : "Choose"}
+                      : 'Choose'}
                   </Text>
                 </Button>
               </Div>

--- a/example/src/components/Select.tsx
+++ b/example/src/components/Select.tsx
@@ -1,12 +1,12 @@
-import React from "react";
-import { ScrollView } from "react-native";
-import { Button, Div, Select, Text } from "react-native-magnus";
-import { SelectRef } from "src/ui/select/select.type";
-import ExamplePage from "../utils/ExamplePage";
-import ExampleHeader from "../utils/ExampleHeader";
-import ExampleSection from "../utils/ExampleSection";
+import React from 'react';
+import { ScrollView } from 'react-native';
+import { Button, Div, Input, Select, Text } from 'react-native-magnus';
+import { SelectRef } from 'src/ui/select/select.type';
+import ExamplePage from '../utils/ExamplePage';
+import ExampleHeader from '../utils/ExampleHeader';
+import ExampleSection from '../utils/ExampleSection';
 
-import { countryCodes, CountryCodeType } from "../utils/countryCodes";
+import { countryCodes, CountryCodeType } from '../utils/countryCodes';
 
 const SelectComponent: React.FC = () => {
   const [selectValue1, setSelectedValue1] = React.useState<string | null>(null);
@@ -41,7 +41,7 @@ const SelectComponent: React.FC = () => {
             borderColor="gray300"
             onPress={() => selectRef1.current?.open()}
           >
-            <Text>{selectValue1 ? selectValue1 : "Select"}</Text>
+            <Text>{selectValue1 ? selectValue1 : 'Select'}</Text>
           </Button>
 
           <Select
@@ -71,7 +71,7 @@ const SelectComponent: React.FC = () => {
             onPress={() => selectRef2.current?.open()}
           >
             <Text>
-              {selectValue2.length ? selectValue2.toString() : "Select"}
+              {selectValue2.length ? selectValue2.toString() : 'Select'}
             </Text>
           </Button>
 
@@ -92,7 +92,7 @@ const SelectComponent: React.FC = () => {
           />
         </ExampleSection>
 
-        <ExampleSection name="searchable">
+        <ExampleSection name="searchable + custom search input">
           <Button
             flex={1}
             block
@@ -102,21 +102,43 @@ const SelectComponent: React.FC = () => {
             borderColor="gray300"
             onPress={() => selectRef3.current?.open()}
           >
-            <Text>{selectValue3 ? selectValue3 : "Select"}</Text>
+            <Text>{selectValue3 ? selectValue3 : 'Select'}</Text>
           </Button>
 
           <Select
-            searchableProps={[""]}
+            searchableProps="*"
             onSelect={(value) => setSelectedValue3(value)}
             ref={selectRef3}
             value={selectValue3}
             title="This is your title"
             message="This is the long message used to set some context"
             roundedTop="xl"
-            data={[1, 2, 3, 4, 5, 6]}
-            renderItem={(item, index) => (
+            data={[
+              'Option 1',
+              'Option 2',
+              'Option 3',
+              'Option 4',
+              'Option 5',
+              'Option 6',
+            ]}
+            renderSearchInput={({ clearText }) => (
+              <Input
+                rounded="none"
+                placeholder="Search"
+                bg="red500"
+                color="white"
+                placeholderTextColor="white"
+                mb="lg"
+                suffix={
+                  <Button bg="red800" onPress={() => clearText()}>
+                    Clear
+                  </Button>
+                }
+              />
+            )}
+            renderItem={(item: number) => (
               <Select.Option value={item} py="md" px="xl">
-                <Text>Option {index + 1}</Text>
+                <Text>{item}</Text>
               </Select.Option>
             )}
           />
@@ -132,7 +154,7 @@ const SelectComponent: React.FC = () => {
             borderColor="gray300"
             onPress={() => selectRef4.current?.open()}
           >
-            <Text>{selectValue4 ? `+${selectValue4.dialCode}` : "Select"}</Text>
+            <Text>{selectValue4 ? `+${selectValue4.dialCode}` : 'Select'}</Text>
           </Button>
 
           <Select
@@ -140,7 +162,7 @@ const SelectComponent: React.FC = () => {
             value={selectValue4}
             data={countryCodes}
             onSelect={(value) => setSelectedValue4(value)}
-            searchableProps={["country.name", "dialCode"]}
+            searchableProps={['country.name', 'dialCode']}
             roundedTop="xl"
             title="Country phone code"
             renderItem={(item: CountryCodeType, index) => (
@@ -177,8 +199,8 @@ const SelectComponent: React.FC = () => {
           >
             <Text>
               {selectValue5.length
-                ? selectValue5.map((item) => `+${item.dialCode}`).join(", ")
-                : "Select"}
+                ? selectValue5.map((item) => `+${item.dialCode}`).join(', ')
+                : 'Select'}
             </Text>
           </Button>
 
@@ -188,7 +210,7 @@ const SelectComponent: React.FC = () => {
             value={selectValue5}
             data={countryCodes}
             onSelect={(value) => setSelectedValue5(value)}
-            searchableProps={["country.name", "dialCode"]}
+            searchableProps={['country.name', 'dialCode']}
             roundedTop="xl"
             title="Country phone code"
             renderItem={(item: CountryCodeType, index) => (

--- a/src/ui/select/select.component.tsx
+++ b/src/ui/select/select.component.tsx
@@ -48,14 +48,16 @@ const Select = React.forwardRef<SelectRef, SelectProps>((props, ref) => {
   const computedStyle = getStyle(theme, props);
 
   const resolveMultiLevelAccess = (obj: any, key: string) => {
-    if (key.length === 0) {
-      return obj;
-    }
-
     return key.split('.').reduce((cur: any, keySection: string) => {
-      if (!cur) {
+      if (cur === null || cur === undefined) {
         return;
       }
+
+      if (cur[keySection] === null || cur[keySection] === undefined) {
+        console.warn(`Property "${key}" does not exists! `);
+        return;
+      }
+
       return cur[keySection];
     }, obj);
   };
@@ -248,15 +250,7 @@ const Select = React.forwardRef<SelectRef, SelectProps>((props, ref) => {
   };
 
   const renderNoResultsFound = () => {
-    if (renderNoResultsView) {
-      renderNoResultsView(searchTerm);
-    }
-
-    return (
-      <Div flex={1} px="2xl" py="xl">
-        <Text fontSize="lg">No results found for "{searchTerm}"</Text>
-      </Div>
-    );
+    renderNoResultsView && renderNoResultsView(searchTerm);
   };
 
   return (
@@ -314,6 +308,11 @@ Select.defaultProps = {
   isVisible: false,
   // mb: 'xl',
   // @ts-ignore
+  renderNoResultsView: (searchTerm) => (
+    <Div flex={1} px="2xl" py="xl">
+      <Text fontSize="lg">No results found for "{searchTerm}"</Text>
+    </Div>
+  ),
   keyExtractor: (item, index) => `${index}`,
 };
 

--- a/src/ui/select/select.component.tsx
+++ b/src/ui/select/select.component.tsx
@@ -1,7 +1,13 @@
 import * as React from 'react';
 import RNModal from 'react-native-modal';
 import { SafeAreaView, FlatList } from 'react-native';
-import { useContext, useState, useImperativeHandle, useEffect } from 'react';
+import {
+  useContext,
+  useState,
+  useImperativeHandle,
+  useEffect,
+  useMemo,
+} from 'react';
 
 import { getStyle } from './select.style';
 import { Div } from '../div/div.component';
@@ -12,16 +18,22 @@ import { Icon } from '../icon/icon.component';
 import { Option } from './select.option.component';
 import { Button } from '../button/button.component';
 import { SelectProps, SelectRef, CompoundedSelect } from './select.type';
+import { InputProps } from '../input/input.type';
+import { ButtonProps } from '../button/button.type';
 
 const Select = React.forwardRef<SelectRef, SelectProps>((props, ref) => {
   const {
     value,
     title,
+    message,
     footer,
     data,
     multiple,
     renderItem,
     keyExtractor,
+    renderNoResultsView,
+    renderSubmitButton,
+    renderSearchInput,
     searchableProps,
     onSelect: onSelectProp,
   } = props;
@@ -29,38 +41,52 @@ const Select = React.forwardRef<SelectRef, SelectProps>((props, ref) => {
   const [visible, setVisible] = useState(props.isVisible || false);
   const [selectedValue, setSelectedValue] = useState(value);
   const [searchTerm, setSearchTerm] = useState<string>('');
+  const isSearchable = useMemo(() => !!searchableProps?.length, [
+    searchableProps,
+  ]);
 
   const computedStyle = getStyle(theme, props);
 
   const resolveMultiLevelAccess = (obj: any, key: string) => {
-    if (key.length === 0) return obj;
+    if (key.length === 0) {
+      return obj;
+    }
 
     return key.split('.').reduce((cur: any, keySection: string) => {
-      if (!cur) return;
+      if (!cur) {
+        return;
+      }
       return cur[keySection];
     }, obj);
   };
 
-  const filterData = (data: any[], searchTerm: string) => {
-    if (!searchableProps || !searchableProps.length) return data;
+  const filteredData = useMemo(() => {
+    if (
+      !searchableProps ||
+      (Array.isArray(searchableProps) && !searchableProps.length)
+    ) {
+      return data;
+    }
 
-    var lowSearch = searchTerm.toLowerCase();
     return data.filter((item) => {
-      return searchableProps.some((key) =>
+      const lowSearch = searchTerm.toLowerCase();
+
+      if (!Array.isArray(searchableProps)) {
+        return String(item).toLowerCase().includes(lowSearch);
+      }
+
+      return searchableProps.some((key: string) =>
         String(resolveMultiLevelAccess(item, key))
           .toLowerCase()
           .includes(lowSearch)
       );
     });
-  };
-
-  const filteredData = React.useMemo(() => filterData(data, searchTerm), [
-    data,
-    searchTerm,
-  ]);
+  }, [searchableProps, searchTerm, data]);
 
   useEffect(() => {
-    if (visible) setSearchTerm('');
+    if (visible) {
+      clearSearchInput();
+    }
 
     if ('isVisible' in props) {
       setVisible(props.isVisible || visible);
@@ -114,13 +140,7 @@ const Select = React.forwardRef<SelectRef, SelectProps>((props, ref) => {
   const renderTitle = () => {
     if (title) {
       return typeof title === 'string' ? (
-        <Text
-          px="xl"
-          py="xl"
-          fontSize="lg"
-          fontWeight="bold"
-          textTransform="uppercase"
-        >
+        <Text px="xl" fontSize="lg" fontWeight="bold" textTransform="uppercase">
           {title}
         </Text>
       ) : (
@@ -132,64 +152,110 @@ const Select = React.forwardRef<SelectRef, SelectProps>((props, ref) => {
   };
 
   /**
-   * render searchbar at top select modal
+   * render message at top select modal
    */
-  const renderSearchbar = () => {
-    if (searchableProps?.length) {
-      return (
-        <Input
-          prefix={
-            <Icon mr="lg" name="search1" color="gray700" fontSize="3xl" />
-          }
-          suffix={
-            searchTerm ? (
-              <Button
-                p="sm"
-                alignSelf="center"
-                rounded="circle"
-                bg="gray700"
-                onPress={() => setSearchTerm('')}
-              >
-                <Icon name="close" color="white" fontSize="xs" />
-              </Button>
-            ) : null
-          }
-          mx="xl"
-          mt="-md"
-          mb="lg"
-          value={searchTerm}
-          onChangeText={(text) => setSearchTerm(text)}
-          fontSize="md"
-          borderWidth={0}
-          placeholder="Search items"
-          bg="gray200"
-        />
+  const renderMessage = () => {
+    if (message) {
+      return typeof message === 'string' ? (
+        <Text px="xl" fontSize="lg">
+          {message}
+        </Text>
+      ) : (
+        message
       );
     }
 
     return false;
   };
 
+  const clearSearchInput = () => setSearchTerm('');
+
+  /**
+   * render searchbar at top select modal
+   */
+  const renderSearchbar = () => {
+    if (!isSearchable) {
+      return;
+    }
+
+    const searchInputElement =
+      renderSearchInput && renderSearchInput({ clearText: clearSearchInput });
+
+    const mandatoryProps: Partial<InputProps> = {
+      value: searchTerm,
+      onChangeText: (text: string) => setSearchTerm(text),
+      autoCompleteType: 'off',
+    };
+
+    if (searchInputElement) {
+      return React.cloneElement(searchInputElement, mandatoryProps);
+    }
+
+    return (
+      <Input
+        prefix={<Icon mr="lg" name="search1" color="gray700" fontSize="3xl" />}
+        suffix={
+          searchTerm ? (
+            <Button
+              p="sm"
+              alignSelf="center"
+              rounded="circle"
+              bg="gray700"
+              onPress={clearSearchInput}
+            >
+              <Icon name="close" color="white" fontSize="xs" />
+            </Button>
+          ) : null
+        }
+        mx="xl"
+        mt="-md"
+        mb="lg"
+        fontSize="md"
+        borderWidth={0}
+        placeholder="Search items"
+        bg="gray200"
+        {...mandatoryProps}
+      />
+    );
+  };
+
   const renderFooter = () => {
-    if (footer) return footer;
+    if (footer) {
+      return footer;
+    }
 
     // if the component is single-valued and no footer is provided
     // don't render anything in footer
-    if (!multiple) return false;
+    if (!multiple) {
+      return;
+    }
+
+    const submitButtonElement = renderSubmitButton && renderSubmitButton();
+
+    const mandatoryProps: Partial<ButtonProps> = {
+      onPress: () => setVisible(false),
+    };
+
+    if (submitButtonElement) {
+      return React.cloneElement(submitButtonElement, mandatoryProps);
+    }
 
     return (
-      <Button
-        block
-        bg="green600"
-        mx="xl"
-        mt="lg"
-        mb="xl"
-        onPress={() => {
-          setVisible(false);
-        }}
-      >
+      <Button block bg="green600" mx="xl" mt="lg" mb="xl" {...mandatoryProps}>
         Submit
       </Button>
+    );
+  };
+
+  const renderNoResultsFound = () => {
+    if (renderNoResultsView) {
+      renderNoResultsView(searchTerm);
+    }
+
+    return (
+      <Div flex={1} px="2xl" py="xl">
+        <Text fontSize="lg">No results found for "{searchTerm}"</Text>
+      </Div>
     );
   };
 
@@ -210,7 +276,10 @@ const Select = React.forwardRef<SelectRef, SelectProps>((props, ref) => {
       <Div style={computedStyle.wrapper}>
         <SafeAreaView style={computedStyle.container}>
           <Div>
-            <Div>{renderTitle()}</Div>
+            <Div py="xl">
+              {renderTitle()}
+              {renderMessage()}
+            </Div>
             <Div>{renderSearchbar()}</Div>
           </Div>
 
@@ -228,9 +297,7 @@ const Select = React.forwardRef<SelectRef, SelectProps>((props, ref) => {
               />
             </Div>
           ) : (
-            <Div flex={1} px="2xl" py="xl">
-              <Text fontSize="lg">No results found.</Text>
-            </Div>
+            renderNoResultsFound()
           )}
 
           {renderFooter()}

--- a/src/ui/select/select.type.tsx
+++ b/src/ui/select/select.type.tsx
@@ -63,5 +63,9 @@ export interface SelectProps
   renderItem: (item: any, index: number) => React.ReactElement;
   keyExtractor?: (item: any, index: number) => string;
   isVisible?: boolean;
-  searchableProps?: string[];
+
+  searchableProps?: '*' | string[];
+  renderNoResultsView?: (searchTerm: string) => React.ReactElement;
+  renderSubmitButton?: () => React.ReactElement;
+  renderSearchInput?: (props: { clearText: () => void }) => React.ReactElement;
 }


### PR DESCRIPTION
Select 'search' fixed and some improvements on Select itself.

Added much props to control views render, like search input, 'no results' view on search, 'submit button' when using multiple={true}, 'message' to appear on bottom of title.

Now, if you pass a string/integer array as data, you can set searchableProps='*' to be able to search it. Custom objects still use an array of props (on which you can use multi-level props using, for example, 'user.name') and you will receive a warning if property is not found.