### PR TITLE
Added textTransform to Button props

### DIFF
--- a/example/src/components/Button.tsx
+++ b/example/src/components/Button.tsx
@@ -1,10 +1,10 @@
-import React from "react";
-import { ScrollView } from "react-native";
-import { Button, Div, Icon } from "react-native-magnus";
+import React from 'react';
+import { ScrollView } from 'react-native';
+import { Button, Div, Icon } from 'react-native-magnus';
 
-import ExamplePage from "../utils/ExamplePage";
-import ExampleHeader from "../utils/ExampleHeader";
-import ExampleSection from "../utils/ExampleSection";
+import ExamplePage from '../utils/ExamplePage';
+import ExampleHeader from '../utils/ExampleHeader';
+import ExampleSection from '../utils/ExampleSection';
 
 const ButtonComponent: React.FC = () => {
   return (
@@ -149,6 +149,7 @@ const ButtonComponent: React.FC = () => {
               px="2xl"
               mr="md"
               bg="black"
+              textTransform="uppercase"
               suffix={<Icon name="arrowright" ml="md" color="white" />}
             >
               Contact Us
@@ -156,6 +157,7 @@ const ButtonComponent: React.FC = () => {
             <Button
               px="2xl"
               rounded="circle"
+              textTransform="uppercase"
               prefix={<Icon name="caretright" mr="md" color="white" />}
             >
               Play now

--- a/src/ui/button/button.style.tsx
+++ b/src/ui/button/button.style.tsx
@@ -47,6 +47,8 @@ export const getStyle = (theme: any, props: any) => {
     color: getThemeProperty(theme.colors, props.color),
     fontSize: getThemeProperty(theme.fontSize, props.fontSize),
     lineHeight: getThemeProperty(theme.fontSize, props.fontSize) * 1.2,
+    textTransform: props.textTransform,
+    letterSpacing: props.letterSpacing,
   };
 
   computedStyle.loadingContainer = {

--- a/src/ui/button/button.type.ts
+++ b/src/ui/button/button.type.ts
@@ -55,4 +55,6 @@ export interface ButtonProps
   ripple?: boolean;
   opacity?: number;
   zIndex?: number;
+  textTransform?: 'none' | 'uppercase' | 'lowercase' | 'capitalize';
+  letterSpacing?: number;
 }


### PR DESCRIPTION
Allow to 'uppercase/lowercase' text easily on button without custom text component.