### PR TITLE
fixed Header and Collapse components

### DIFF
--- a/example/src/components/Header.tsx
+++ b/example/src/components/Header.tsx
@@ -35,7 +35,10 @@ const HeaderComponent: React.FC = () => {
           </Header>
         </ExampleSection>
 
-        <ExampleSection name="center aligned + prefix" withoutSpacingOnContent>
+        <ExampleSection
+          name="center aligned + prefix/suffix"
+          withoutSpacingOnContent
+        >
           <Header
             p="lg"
             borderBottomWidth={1}
@@ -44,6 +47,11 @@ const HeaderComponent: React.FC = () => {
             prefix={
               <Button bg="white">
                 <Icon name="arrow-left" fontFamily="Feather" fontSize="2xl" />
+              </Button>
+            }
+            suffix={
+              <Button bg="white">
+                <Icon name="arrow-right" fontFamily="Feather" fontSize="2xl" />
               </Button>
             }
           >

--- a/src/ui/collapse/collapse.component.tsx
+++ b/src/ui/collapse/collapse.component.tsx
@@ -12,7 +12,6 @@ import { CollapseGroup } from './group.component';
 const Collapse: CompoundedCollapse<CollapseProps> = (incomingProps) => {
   const props = useDefaultProps('Collapse', incomingProps, {
     bg: 'white',
-    active: false,
     flexDir: 'column',
     flexWrap: 'nowrap',
     rounded: 'md',
@@ -35,7 +34,7 @@ const Collapse: CompoundedCollapse<CollapseProps> = (incomingProps) => {
 
   useEffect(() => {
     if ('active' in props) {
-      setIsActive(props.active);
+      setIsActive(props.active ?? false);
     }
   }, [props]);
 

--- a/src/ui/header/header.component.tsx
+++ b/src/ui/header/header.component.tsx
@@ -24,7 +24,6 @@ const Header: React.FunctionComponent<HeaderProps> = (incomingProps) => {
     borderStyle: 'solid',
     alignItems: 'center',
     alignment: 'left',
-    prefix: <Div px="sm" />,
     fontWeight: 'bold',
     fontSize: 'lg',
     textTransform: 'uppercase',
@@ -53,9 +52,14 @@ const Header: React.FunctionComponent<HeaderProps> = (incomingProps) => {
     return children;
   };
 
+  const getPrefix = () => {
+    if (props.alignment === 'center') return prefix;
+    return prefix ?? <Div px="sm" />;
+  };
+
   return (
     <Div {...rest}>
-      <Div style={computedStyle.prefix}>{prefix}</Div>
+      <Div style={computedStyle.prefix}>{getPrefix()}</Div>
       <Div style={computedStyle.center}>{renderChildren()}</Div>
       <Div style={computedStyle.suffix}>{suffix}</Div>
     </Div>

--- a/src/ui/header/header.style.tsx
+++ b/src/ui/header/header.style.tsx
@@ -21,7 +21,9 @@ export const getStyle = (_theme: ThemeType, props: HeaderProps) => {
     };
   }
 
-  computedStyle.center = {};
+  computedStyle.center = {
+    flex: 1,
+  };
 
   if (props.suffix) {
     computedStyle.suffix = {
@@ -52,13 +54,11 @@ export const getStyle = (_theme: ThemeType, props: HeaderProps) => {
     if (props.suffix || props.prefix) {
       computedStyle.center = {
         ...computedStyle.center,
-        ...StyleSheet.absoluteFillObject,
       };
     }
   } else {
     computedStyle.suffix = {
       ...computedStyle.suffix,
-      flex: 1,
       justifyContent: 'flex-end',
     };
   }


### PR DESCRIPTION
- Collapse 'active' prop working again
- Header default prefix (to align text correctly and let most basic use-case have less code) will only appear when 'alignment' is 'left'