### PR TITLE
Added suffix prop in SelectOptionProps

### DIFF
--- a/src/ui/select/select.option.type.tsx
+++ b/src/ui/select/select.option.type.tsx
@@ -28,6 +28,7 @@ export interface SelectOptionProps
     FlexPropsType,
     ButtonPropsType,
     Pick<PrefixSuffixPropsType, 'prefix'>,
+    Pick<PrefixSuffixPropsType, 'suffix'>,
     Pick<BackgroundPropsType, 'bg'>,
     DimensionPropsType,
     Pick<TextPropsType, 'color' | 'fontSize'>,


### PR DESCRIPTION
Added `suffix` prop in select options props. It also fixes a Typescript warning when adding the suffix prop to `<Select.Option>`.