### PR TITLE
Suggestion: Remove unnecessary peer dependency

### DIFF
--- a/docs/content/docs/getting-started.md
+++ b/docs/content/docs/getting-started.md
@@ -15,7 +15,7 @@ yarn add react-native-magnus
 After installing the `react-native-magnus`, make sure you install peer dependencies.
 
 ```bash
-yarn add color react-native-animatable react-native-modal react-native-vector-icons deepmerge validate-color
+yarn add color react-native-animatable react-native-modal react-native-vector-icons
 ```
 
 After installing these dependencies, follow these instructions to add icons : https://github.com/oblador/react-native-vector-icons#installation

--- a/package.json
+++ b/package.json
@@ -74,13 +74,11 @@
   },
   "peerDependencies": {
     "color": "^3.1.2",
-    "deepmerge": "^4.2.2",
     "react": "*",
     "react-native": "*",
     "react-native-animatable": "^1.3.3",
     "react-native-modal": "^11.5.6",
-    "react-native-vector-icons": "^6.6.0",
-    "validate-color": "^2.1.1"
+    "react-native-vector-icons": "^6.6.0"
   },
   "jest": {
     "preset": "react-native",


### PR DESCRIPTION
`deepmerge` and `validate-color` is include in `dependencies`.
I think those packages not need `peerDependency`