### PR TITLE
Fix renderNoResultsView not rendering

### DIFF
--- a/src/ui/select/select.component.tsx
+++ b/src/ui/select/select.component.tsx
@@ -268,9 +268,8 @@ const Select = React.forwardRef<SelectRef, SelectProps>(
       );
     };
 
-    const renderNoResultsFound = () => {
+    const renderNoResultsFound = () =>
       renderNoResultsView && renderNoResultsView(searchTerm);
-    };
 
     return (
       <RNModal


### PR DESCRIPTION
This fixes the `renderNoResultsView` component from not rendering. The function was returning `void` instead of the component.

Fixes #94 