### PR TITLE
fix(types.ts): string support to PositionPropsType

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -188,10 +188,10 @@ export const positionProps = [
 ] as const;
 export interface PositionPropsType {
   position?: 'absolute' | 'relative';
-  top?: number;
-  right?: number;
-  bottom?: number;
-  left?: number;
+  top?: number | string;
+  right?: number | string;
+  bottom?: number | string;
+  left?: number | string;
 }
 
 export const backgroundProps = ['bg', 'bgImg', 'bgMode'] as const;


### PR DESCRIPTION
Hi, I've added `string` to `PositionPropsType` because currently React Native support using percentage values into this props.

```typescript
top="25%"
bottom="75%"
left="50%"
right="100%"
```

All of this props works but the type won't allow it.