### PR TITLE
docs: add docs for customizing components styles

### DIFF
--- a/docs/content/docs/customization.md
+++ b/docs/content/docs/customization.md
@@ -23,6 +23,14 @@ const theme = {
   spacing: {
     xs: 2,
     '5xl': 64
+  },
+  // components defaults can also be customized
+  {
+    components: {
+      Text: {
+        color: 'gray100'
+      }
+    }
   }
 };
 


### PR DESCRIPTION
Adds an example to customize default `color` for `Text` component