### PR TITLE
docs: Fix reference issue on Overlay component

### DIFF
--- a/docs/content/docs/overlay/index.md
+++ b/docs/content/docs/overlay/index.md
@@ -1,7 +1,7 @@
 ---
 title: Overlay
-date: "2019-08-13"
-description: ""
+date: '2019-08-13'
+description: ''
 ---
 
 <br />
@@ -36,28 +36,28 @@ const [overlayVisible, setOverlayVisible] = useState(false);
 
 ## Props
 
-| Property      | Description          | Type              | Default |
-| ------------- | -------------------- | ----------------- | ------- |
-| m             | margin               | `string | number` | -       |
-| mt            | margin top           | `string | number` | -       |
-| mr            | margin right         | `string | number` | -       |
-| mb            | margin bottom        | `string | number` | -       |
-| ml            | margin margin left   | `string | number` | -       |
-| mx            | margin horizonal     | `string | number` | -       |
-| my            | margin vertical      | `string | number` | -       |
-| p             | padding              | `string | number` | -       |
-| pt            | padding top          | `string | number` | -       |
-| pr            | padding right        | `string | number` | -       |
-| pb            | padding bottom       | `string | number` | -       |
-| pl            | padding margin left  | `string | number` | -       |
-| px            | padding horizonal    | `string | number` | -       |
-| py            | padding vertical     | `string | number` | -       |
-| h             | height of modal      | `number`          | `100%`  |
-| bg            | background of modal  | `string`          | `white` |
-| rounded       | border radius        | `string | number` | `none`  |
-| roundedTop    | border radius top    | `string | number` | `none`  |
-| roundedBottom | border radius bottom | `string | number` | `none`  |
-| roundedLeft   | border radius left   | `string | number` | `none`  |
-| roundedRight  | border radius right  | `string | number` | `none`  |
+| Property      | Description          | Type     | Default |
+| ------------- | -------------------- | -------- | ------- | ------ |
+| m             | margin               | `string  | number` | -      |
+| mt            | margin top           | `string  | number` | -      |
+| mr            | margin right         | `string  | number` | -      |
+| mb            | margin bottom        | `string  | number` | -      |
+| ml            | margin margin left   | `string  | number` | -      |
+| mx            | margin horizonal     | `string  | number` | -      |
+| my            | margin vertical      | `string  | number` | -      |
+| p             | padding              | `string  | number` | -      |
+| pt            | padding top          | `string  | number` | -      |
+| pr            | padding right        | `string  | number` | -      |
+| pb            | padding bottom       | `string  | number` | -      |
+| pl            | padding margin left  | `string  | number` | -      |
+| px            | padding horizonal    | `string  | number` | -      |
+| py            | padding vertical     | `string  | number` | -      |
+| h             | height of modal      | `number` | `100%`  |
+| bg            | background of modal  | `string` | `white` |
+| rounded       | border radius        | `string  | number` | `none` |
+| roundedTop    | border radius top    | `string  | number` | `none` |
+| roundedBottom | border radius bottom | `string  | number` | `none` |
+| roundedLeft   | border radius left   | `string  | number` | `none` |
+| roundedRight  | border radius right  | `string  | number` | `none` |
 
-Apart from these props, The `<Modal />` also accepts all props available in [react-native-modal](https://github.com/react-native-community/react-native-modal).
+Apart from these props, The `<Overlay />` also accepts all props available in [React Native Modal component](https://reactnative.dev/docs/modal).


### PR DESCRIPTION
The previous doc redirected users on `react-native-modal <Modal />` component instead of redirecting them on React Native `<Modal />` one. It's fixed !