### PR TITLE
Fix: remove unnecessary defaultProps on Skeleton

### DIFF
--- a/src/ui/skeleton/skeleton.component.tsx
+++ b/src/ui/skeleton/skeleton.component.tsx
@@ -55,7 +55,7 @@ export const Circle: React.FunctionComponent<SkeletonProps> = (
   return <Skeleton {...props} />;
 };
 
-Skeleton.defaultProps = {
+/* Skeleton.defaultProps = {
   bg: 'gray400',
   h: 15,
   w: '100%',
@@ -68,7 +68,7 @@ Circle.defaultProps = {
   h: 15,
   w: 15,
   rounded: 'circle',
-};
+}; */
 
 Skeleton.Box = Skeleton;
 Skeleton.Circle = Circle;


### PR DESCRIPTION
This change resolves the following warning for expo v51:

Warning: Skeleton: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.

PS: This is my first contribution. Please let me know if I followed the guidelines correctly.